### PR TITLE
Make color correction LUTs optional.

### DIFF
--- a/Source/HedgeGI/Application.cpp
+++ b/Source/HedgeGI/Application.cpp
@@ -978,6 +978,9 @@ void Application::drawSettingsUI()
         if (game == Game::Generations && bakeParams.targetEngine == TargetEngine::HE1)
             property("Gamma Correction", gammaCorrectionFlag);
 
+        if (bakeParams.targetEngine == TargetEngine::HE2)
+            property("Color Correction", colorCorrectionFlag);
+
         property("Viewport Resolution", ImGuiDataType_Float, &viewportResolutionInvRatio);
 
         endProperties();
@@ -1299,6 +1302,7 @@ void Application::loadProperties()
     bakeParams.load(propertyBag);
     viewportResolutionInvRatio = propertyBag.get(PROP("viewportResolutionInvRatio"), 2.0f);
     gammaCorrectionFlag = propertyBag.get(PROP("gammaCorrectionFlag"), true);
+    colorCorrectionFlag = propertyBag.get(PROP("colorCorrectionFlag"), true);
     outputDirectoryPath = propertyBag.getString(PROP("outputDirectoryPath"), stageDirectoryPath + "-HedgeGI");
     mode = propertyBag.get(PROP("mode"), BakingFactoryMode::GI);
     skipExistingFiles = propertyBag.get(PROP("skipExistingFiles"), false);
@@ -1313,6 +1317,7 @@ void Application::storeProperties()
     bakeParams.store(propertyBag);
     propertyBag.set(PROP("viewportResolutionInvRatio"), viewportResolutionInvRatio);
     propertyBag.set(PROP("gammaCorrectionFlag"), gammaCorrectionFlag);
+    propertyBag.set(PROP("colorCorrectionFlag"), colorCorrectionFlag);
     propertyBag.setString(PROP("outputDirectoryPath"), outputDirectoryPath);
     propertyBag.set(PROP("mode"), mode);
     propertyBag.set(PROP("skipExistingFiles"), skipExistingFiles);
@@ -2078,6 +2083,11 @@ const SceneEffect& Application::getSceneEffect() const
 bool Application::getGammaCorrectionFlag() const
 {
     return gammaCorrectionFlag;
+}
+
+bool Application::getColorCorrectionFlag() const
+{
+    return colorCorrectionFlag;
 }
 
 const BakeParams Application::getBakeParams() const

--- a/Source/HedgeGI/Application.h
+++ b/Source/HedgeGI/Application.h
@@ -86,6 +86,7 @@ class Application
 
     float viewportResolutionInvRatio {};
     bool gammaCorrectionFlag {};
+    bool colorCorrectionFlag {};
     BakeParams bakeParams;
 
     BakingFactoryMode mode {};
@@ -192,6 +193,7 @@ public:
     const RaytracingContext getRaytracingContext() const;
     const SceneEffect& getSceneEffect() const;
     bool getGammaCorrectionFlag() const;
+    bool getColorCorrectionFlag() const;
     const BakeParams getBakeParams() const;
 
     void drawQuad() const;

--- a/Source/HedgeGI/Viewport.cpp
+++ b/Source/HedgeGI/Viewport.cpp
@@ -97,7 +97,7 @@ void Viewport::toneMap(const Application& application) const
         application.getGame() == Game::Generations && application.getGammaCorrectionFlag() ? 1.5f :
         1.0f);
 
-    const bool enableRgbTable = application.getBakeParams().targetEngine == TargetEngine::HE2 && rgbTable != nullptr;
+    const bool enableRgbTable = application.getBakeParams().targetEngine == TargetEngine::HE2 && application.getColorCorrectionFlag() && rgbTable != nullptr;
 
     toneMapShader.set("uEnableRgbTable", enableRgbTable);
 


### PR DESCRIPTION
Adds the option to toggle color correction LUTs. Useful for if the user wants to see the stage without them. (similarly to toggling Generations' gamma correction)

![2021-08-19_18-57-02_HedgeGI](https://user-images.githubusercontent.com/15317421/130166955-22d5fc3a-cc66-42d5-a0ef-a61dd9c92bfd.png)

![2021-08-19_18-57-06_HedgeGI](https://user-images.githubusercontent.com/15317421/130166962-f6c6a105-6061-4a41-9255-6015aae4d7c9.png)
