### PR TITLE
Allow saving HE1 lightmaps as BC7

### DIFF
--- a/Source/HedgeGI/BakingFactoryWindow.cpp
+++ b/Source/HedgeGI/BakingFactoryWindow.cpp
@@ -66,6 +66,10 @@ const Label OPTIMIZE_SEAMS_LABEL = { "Optimize Seams",
 const Label SKIP_EXISTING_FILES_LABEL = { "Skip Existing Files",
     "Skips instances that already have their resulting images in the output directory." };
 
+const Label SAVE_AS_BC7_LABEL = { "Save As BC7",
+    "Saves lightmap atlases using the higher-quality BC7 compression.\n\n" 
+    "This will only work in games that support handling said format, such as Unleashed Recompiled or Generations with the D3D11 mod." };
+
 const Label DENOISER_NONE_LABEL = { "None",
     "Disables denoising. This is going to cause resulting images to look really noisy." };
 
@@ -223,6 +227,9 @@ void BakingFactoryWindow::update(const float deltaTime)
                 property(DENOISE_SHADOW_MAP_LABEL, params->postProcess.denoiseShadowMap);
                 property(OPTIMIZE_SEAMS_LABEL, params->postProcess.optimizeSeams);
                 property(SKIP_EXISTING_FILES_LABEL, params->skipExistingFiles);
+
+                if(params->targetEngine == TargetEngine::HE1)
+                    property(SAVE_AS_BC7_LABEL, params->saveAsBc7);
 
                 // Denoiser types need special handling since they might not be available
                 if (OptixDenoiserDevice::available || OidnDenoiserDevice::available)

--- a/Source/HedgeGI/BakingFactoryWindow.cpp
+++ b/Source/HedgeGI/BakingFactoryWindow.cpp
@@ -66,9 +66,9 @@ const Label OPTIMIZE_SEAMS_LABEL = { "Optimize Seams",
 const Label SKIP_EXISTING_FILES_LABEL = { "Skip Existing Files",
     "Skips instances that already have their resulting images in the output directory." };
 
-const Label SAVE_AS_BC7_LABEL = { "Save As BC7",
+const Label SAVE_AS_BC7_LABEL = { "Save as BC7",
     "Saves lightmap atlases using the higher-quality BC7 compression.\n\n" 
-    "This will only work in games that support handling said format, such as Unleashed Recompiled or Generations with the D3D11 mod." };
+    "This will only work in games that support handling said format, such as Unleashed Recompiled or Sonic Generations with the D3D11 mod." };
 
 const Label DENOISER_NONE_LABEL = { "None",
     "Disables denoising. This is going to cause resulting images to look really noisy." };

--- a/Source/HedgeGI/PackService.cpp
+++ b/Source/HedgeGI/PackService.cpp
@@ -214,7 +214,7 @@ void PackService::packUnleashedOrGenerationsGI()
     const auto stage = get<Stage>();
     const auto params = get<StageParams>();
 
-    PostRender::process(stage->getDirectoryPath(), params->outputDirectoryPath, stage->getGame(), params->targetEngine);
+    PostRender::process(stage->getDirectoryPath(), params->outputDirectoryPath, stage->getGame(), params->targetEngine, params->saveAsBc7);
 }
 
 void PackService::packLostWorldOrForcesGI()

--- a/Source/HedgeGI/PostRender.cpp
+++ b/Source/HedgeGI/PostRender.cpp
@@ -500,6 +500,7 @@ hl::archive PostRender::createArchive(const std::string& inputDirectoryPath, Tar
                     *tmpImage);
             }
             else
+            {
                 DirectX::Compress(
                     atlasImage->GetImages(),
                     atlasImage->GetImageCount(),
@@ -508,6 +509,7 @@ hl::archive PostRender::createArchive(const std::string& inputDirectoryPath, Tar
                     DirectX::TEX_COMPRESS_PARALLEL,
                     DirectX::TEX_THRESHOLD_DEFAULT,
                     *tmpImage);
+            }
 
             atlasImage.swap(tmpImage);
         }

--- a/Source/HedgeGI/PostRender.h
+++ b/Source/HedgeGI/PostRender.h
@@ -32,7 +32,7 @@ public:
     static std::vector<Atlas> createAtlases(std::list<Texture>& textures);
 
     static hl::archive createArchive(const std::string& inputDirectoryPath, TargetEngine targetEngine,
-        hl::hh::mirage::raw_gi_texture_group* group, hl::hh::mirage::raw_gi_texture_group_info_v2* groupInfo);
+        hl::hh::mirage::raw_gi_texture_group* group, hl::hh::mirage::raw_gi_texture_group_info_v2* groupInfo, bool preferBC7);
 
-    static void process(const std::string& stageDirectoryPath, const std::string& inputDirectoryPath, Game game, TargetEngine targetEngine);
+    static void process(const std::string& stageDirectoryPath, const std::string& inputDirectoryPath, Game game, TargetEngine targetEngine, bool preferBC7);
 };

--- a/Source/HedgeGI/StageParams.h
+++ b/Source/HedgeGI/StageParams.h
@@ -23,6 +23,7 @@ public:
 
     bool skipExistingFiles{ true };
     bool useExistingLightField{};
+    bool saveAsBc7{};
 
     size_t resolutionSuperSampleScale{ 1 };
 


### PR DESCRIPTION
Adds a bake setting that allows compressing lightmap atlases as BC7:
![checkbox](https://github.com/user-attachments/assets/723763b1-d978-4618-aaad-12186cf942f5)

It only shows up when the engine is set to HE1.