### PR TITLE
DPI Scaling support

### DIFF
--- a/Source/HedgeGI/HedgeGI.vcxproj
+++ b/Source/HedgeGI/HedgeGI.vcxproj
@@ -84,9 +84,12 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\..\Dependencies\Embree\lib;$(CUDA_PATH)\lib\x64;..\..\Dependencies\oidn\lib;..\..\Dependencies\glfw\lib;..\..\Dependencies\DirectXTex\lib;..\..\Dependencies\HedgeLib\lib;..\..\Dependencies\oneTBB\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cuda.lib;cudart_static.lib;d3d11.lib;embree4.lib;embree_sse42.lib;embree_avx.lib;embree_avx2.lib;lexers.lib;math.lib;simd.lib;sys.lib;tasking.lib;tbb12.lib;common.lib;dnnl.lib;OpenImageDenoise.lib;glfw3.lib;DirectXTex.lib;HedgeLib.lib;lz4.lib;cabinet.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cuda.lib;cudart_static.lib;d3d11.lib;embree4.lib;embree_sse42.lib;embree_avx.lib;embree_avx2.lib;lexers.lib;math.lib;simd.lib;sys.lib;tasking.lib;tbb12.lib;common.lib;dnnl.lib;OpenImageDenoise.lib;glfw3.lib;DirectXTex.lib;HedgeLib.lib;lz4.lib;cabinet.lib;zlibstatic.lib;shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent />
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -112,10 +115,13 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalLibraryDirectories>..\..\Dependencies\Embree\lib;$(CUDA_PATH)\lib\x64;..\..\Dependencies\oidn\lib;..\..\Dependencies\glfw\lib;..\..\Dependencies\DirectXTex\lib;..\..\Dependencies\HedgeLib\lib;..\..\Dependencies\oneTBB\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>cuda.lib;cudart_static.lib;d3d11.lib;embree4.lib;embree_sse42.lib;embree_avx.lib;embree_avx2.lib;lexers.lib;math.lib;simd.lib;sys.lib;tasking.lib;tbb12.lib;common.lib;dnnl.lib;OpenImageDenoise.lib;glfw3.lib;DirectXTex.lib;HedgeLib.lib;lz4.lib;cabinet.lib;zlibstatic.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>cuda.lib;cudart_static.lib;d3d11.lib;embree4.lib;embree_sse42.lib;embree_avx.lib;embree_avx2.lib;lexers.lib;math.lib;simd.lib;sys.lib;tasking.lib;tbb12.lib;common.lib;dnnl.lib;OpenImageDenoise.lib;glfw3.lib;DirectXTex.lib;HedgeLib.lib;lz4.lib;cabinet.lib;zlibstatic.lib;shcore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration />
     </Link>
     <PostBuildEvent />
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="..\..\Dependencies\glad\src\glad.c">

--- a/Source/HedgeGI/ImGuiManager.cpp
+++ b/Source/HedgeGI/ImGuiManager.cpp
@@ -1,6 +1,7 @@
 ﻿#include "ImGuiManager.h"
 #include "AppData.h"
 #include "AppWindow.h"
+#include <ShellScalingApi.h>
 
 void ImGuiManager::initializeImGui()
 {
@@ -111,7 +112,7 @@ void ImGuiManager::initializeFonts()
     config.OversampleV = 2;
 
     font = io.Fonts->AddFontFromFileTTF((wideCharToMultiByte(windowsDirectoryPath) + "\\Fonts\\segoeui.ttf").c_str(),
-        16.0f, &config, io.Fonts->GetGlyphRangesDefault());
+        16.5f * getDpiScaling(), &config, io.Fonts->GetGlyphRangesDefault());
 
     io.Fonts->Build();
 }
@@ -144,6 +145,19 @@ void ImGuiManager::initializeDocks()
     ImGui::DockBuilderDockWindow("Logs", bottomRightId);
 
     ImGui::DockBuilderFinish(dockSpaceId);
+}
+
+float ImGuiManager::getDpiScaling()
+{
+    //Get current monitor
+    auto activeWindow = GetActiveWindow();
+    HMONITOR monitor = MonitorFromWindow(activeWindow, MONITOR_DEFAULTTONEAREST);
+
+    UINT dpiX = 0, dpiY = 0;
+    //Get the DPI scaling factor for the current monitor
+    //(e.g 120% = "120")
+    HRESULT result = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &dpiX, &dpiY);
+    return dpiX / 100.0f;
 }
 
 ImGuiManager::ImGuiManager() : font(nullptr)

--- a/Source/HedgeGI/ImGuiManager.h
+++ b/Source/HedgeGI/ImGuiManager.h
@@ -11,6 +11,7 @@ class ImGuiManager final : public Component
     void initializeStyle();
     void initializeFonts();
     void initializeDocks();
+    float getDpiScaling();
 
 public:
     ImGuiManager();


### PR DESCRIPTION
Heyo, this PR adds a very basic method of scaling ImGui based on the DPI of the current monitor, the implementation is windows dependant, and I had to increase the font size by a tiny bit to make it more readable without eye-strain on a 1440p monitor with 125% scaling, but it looks about the same on 100%.